### PR TITLE
v1.0.0

### DIFF
--- a/.github/workflows/Pipeline.yml
+++ b/.github/workflows/Pipeline.yml
@@ -1,3 +1,19 @@
+# The MIT License (MIT)
+#
+# Copyright © 2026 The pyTooling Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 name: Build MiKTeX images
 
 on:
@@ -140,6 +156,8 @@ jobs:
           miktex_version=${MIKTEX_VERSION}
           EOF
 
+# TODO: add miktex version as label to image
+
       - name: 🔑 Login and push '${{ steps.variables.outputs.miktex_image }}' to Docker Hub
         run: |
           DockerImageSizeUncompressed() {
@@ -263,10 +281,10 @@ jobs:
           }
           
           printf -- "Docker image '%s' has %s\n" "${{ steps.variables.outputs.specific_image }}" "$(DockerImageSizeUncompressed ${{ steps.variables.outputs.specific_image }})"
-          printf -- "Labels of '${{ steps.variables.outputs.miktex_image }}':\n"
-          docker inspect --format='{{json .Config.Labels}}' "${{ steps.variables.outputs.miktex_image }}" | jq
+          printf -- "Labels of '${{ steps.variables.outputs.specific_image }}':\n"
+          docker inspect --format='{{json .Config.Labels}}' "${{ steps.variables.outputs.specific_image }}" | jq
           
-          docker container run --rm ${{ steps.variables.outputs.specific_image }} bash -c 'xelatex --version'
+          docker container run --rm ${{ steps.variables.outputs.specific_image }} bash -c 'lualatex --version'
 
       - name: 🔑 Login and push '${{ steps.variables.outputs.specific_image }}' to Docker Hub
         run: |

--- a/Base.packages
+++ b/Base.packages
@@ -2,4 +2,5 @@ apt-transport-https
 ca-certificates
 gnupg
 curl
+sudo
 tree

--- a/Docker.buildx.sh
+++ b/Docker.buildx.sh
@@ -1,25 +1,20 @@
 #! /bin/bash
-# =============================================================================
-# Authors:          Patrick Lehmann
+# The MIT License (MIT)
 #
-# Entity:           STDOUT Post-Processor for Docker build
+# Copyright © 2026 The pyTooling Authors
 #
-# License:
-# =============================================================================
-# Copyright 2017-2023 Patrick Lehmann - Boetzingen, Germany
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
 #
-#		http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 # shellcheck shell=bash
 
 # Save working directory

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,20 @@
 # check=skip=InvalidDefaultArgInFrom;error=true
-
+# The MIT License (MIT)
+#
+# Copyright © 2026 The pyTooling Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 ARG IMAGE
 ARG MIKTEX_SRC_REPO
 
@@ -48,27 +63,32 @@ RUN configFile="$(find /usr/local/share/miktex-texmf -name "texmfapp.ini" 2>/dev
       printf -- "[NOT FOUND]\n"; \
     fi
 
+RUN groupadd --gid 1000 latex \
+ && useradd --uid 1000 --gid 1000 -m -d /latex latex \
+ && printf -- "latex ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/latex \
+ && chmod 0440 /etc/sudoers.d/latex \
+ && ls -lAh /
+
+WORKDIR /latex
+ENV HOME=/latex
+
 # Install LaTeX packages
 RUN --mount=type=bind,target=/context \
      miktex --admin --verbose packages update-package-database \
  && (miktex --admin --verbose packages install --package-id-file /context/Packages.list || (cat /var/log/miktex/mpmcli_admin.log && exit 1)) \
  && initexmf --admin --update-fndb
 
-ENV MIKTEX_USERCONFIG=/miktex/.miktex/texmfs/config
-ENV MIKTEX_USERDATA=/miktex/.miktex/texmfs/data
-ENV MIKTEX_USERINSTALL=/miktex/.miktex/texmfs/install
-
-ENV MIKTEX_MAINT_GIVEUP_AFTER_DAYS=9999
-
 # Install STDOUT filter scripts for LaTeX
 RUN --mount=type=bind,target=/context \
     install -m 755 /context/filter.latexmk.sh /usr/local/bin/filter.latexmk.sh
 
-RUN groupadd --gid 1000 latex \
- && useradd --uid 1000 --gid 1000 -m -d /latex latex \
- && printf -- "latex ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/latex \
- && chmod 0440 /etc/sudoers.d/latex
+# Configure MiKTeX directories and create directories if mountpoint from host is missing.
+ENV MIKTEX_USERCONFIG=/latex/.miktex/texmfs/config \
+    MIKTEX_USERDATA=/latex/.miktex/texmfs/data \
+    MIKTEX_USERINSTALL=/latex/.miktex/texmfs/install \
+    MIKTEX_MAINT_GIVEUP_AFTER_DAYS=9999
 
-WORKDIR /latex
-ENV HOME=/latex
+RUN mkdir -p $MIKTEX_USERCONFIG $MIKTEX_USERDATA $MIKTEX_USERINSTALL \
+ && chown -R latex:latex /latex
+
 USER latex

--- a/Dockerfile
+++ b/Dockerfile
@@ -63,3 +63,12 @@ ENV MIKTEX_MAINT_GIVEUP_AFTER_DAYS=9999
 # Install STDOUT filter scripts for LaTeX
 RUN --mount=type=bind,target=/context \
     install -m 755 /context/filter.latexmk.sh /usr/local/bin/filter.latexmk.sh
+
+RUN groupadd --gid 1000 latex \
+ && useradd --uid 1000 --gid 1000 -m -d /latex latex \
+ && printf -- "latex ALL=(root) NOPASSWD:ALL" > /etc/sudoers.d/latex \
+ && chmod 0440 /etc/sudoers.d/latex
+
+WORKDIR /latex
+ENV HOME=/latex
+USER latex

--- a/Dockerfile.Specific
+++ b/Dockerfile.Specific
@@ -4,6 +4,8 @@ ARG IMAGE
 
 FROM ${IMAGE}
 
+USER root
+
 # Install dependencies via apt-get
 RUN --mount=type=bind,target=/context \
     apt-get update \
@@ -19,3 +21,5 @@ RUN --mount=type=bind,target=/context \
      miktex --admin --verbose packages update-package-database \
   && (miktex --admin --verbose packages install --package-id-file /context/Packages.list || (cat /var/log/miktex/mpmcli_admin.log && exit 1)) \
   && initexmf --admin --update-fndb
+
+USER latex

--- a/Dockerfile.Specific
+++ b/Dockerfile.Specific
@@ -1,4 +1,20 @@
 # check=skip=InvalidDefaultArgInFrom;error=true
+# The MIT License (MIT)
+#
+# Copyright © 2026 The pyTooling Authors
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
+#
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ARG IMAGE
 

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,16 @@
+# The MIT License (MIT)
+
+Copyright © 2026 The pyTooling Authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -44,3 +44,13 @@ Sphinx specific package list: [Sphinx.list](Sphinx.list)
 ### Pandoc
 
 **planned**
+
+
+## License
+
+This Docker Image build receipt and all it's accompanying configuration and script files (source code) are licensed
+under [The MIT License](LICENSE.md) if not mentioned otherwise within the respective file.
+
+---
+
+SPDX-License-Identifier: MIT

--- a/filter.latexmk.sh
+++ b/filter.latexmk.sh
@@ -1,25 +1,20 @@
 #! /bin/bash
-# =============================================================================
-# Authors:          Patrick Lehmann
+# The MIT License (MIT)
 #
-# Entity:           STDOUT Post-Processor for latexmk
+# Copyright © 2026 The pyTooling Authors
 #
-# License:
-# =============================================================================
-# Copyright 2026-2026 Patrick Lehmann - Boetzingen, Germany
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated
+# documentation files (the “Software”), to deal in the Software without restriction, including without limitation the
+# rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit
+# persons to whom the Software is furnished to do so, subject to the following conditions:
 #
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the
+# Software.
 #
-#		http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-# =============================================================================
+# THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE
+# WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+# COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+# OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ANSI_BLACK=$'\x1b[30m'
 ANSI_RED=$'\x1b[31m'


### PR DESCRIPTION
# New Features

* Container will use user `latex` when executing commands.
  * Added group `latex`.
  * Added user `latex`.
  * Use `/latex` as home and/or working directory.


# Changes

* Changed `MIKTEX_***` variables from `/miktex` to `/latex`.


# Bug Fixes

* Fixed typo in docker inspect call.


# Documentation

* Added MIT License texts.
* Changed some files owned by @Paebbels (Patrick Lehmann) from Apache License 2.0 to MIT License, thus all files have the same license.
